### PR TITLE
Added instances for monoid-cubclasses

### DIFF
--- a/src/Text/Ascii/Internal.hs
+++ b/src/Text/Ascii/Internal.hs
@@ -131,29 +131,29 @@ newtype AsciiText = AsciiText ByteString
       Monoid,
       -- | @since 1.0.0
       Show,
-      -- | @since 1.1.1
+      -- | @since 1.2
       Factorial,
-      -- | @since 1.1.1
+      -- | @since 1.2
       FactorialMonoid,
-      -- | @since 1.1.1
+      -- | @since 1.2
       LeftCancellative,
-      -- | @since 1.1.1
+      -- | @since 1.2
       LeftGCDMonoid,
-      -- | @since 1.1.1
+      -- | @since 1.2
       LeftReductive,
-      -- | @since 1.1.1
+      -- | @since 1.2
       MonoidNull,
-      -- | @since 1.1.1
+      -- | @since 1.2
       OverlappingGCDMonoid,
-      -- | @since 1.1.1
+      -- | @since 1.2
       PositiveMonoid,
-      -- | @since 1.1.1
+      -- | @since 1.2
       RightCancellative,
-      -- | @since 1.1.1
+      -- | @since 1.2
       RightGCDMonoid,
-      -- | @since 1.1.1
+      -- | @since 1.2
       RightReductive,
-      -- | @since 1.1.1
+      -- | @since 1.2
       StableFactorial
     )
     via ByteString

--- a/src/Text/Ascii/Internal.hs
+++ b/src/Text/Ascii/Internal.hs
@@ -27,6 +27,12 @@ import Data.Char (chr, isAscii)
 import Data.Coerce (coerce)
 import Data.Hashable (Hashable)
 import qualified Data.List.NonEmpty as NE
+import Data.Monoid.Factorial (FactorialMonoid)
+import Data.Monoid.GCD (LeftGCDMonoid, RightGCDMonoid)
+import Data.Monoid.Monus (OverlappingGCDMonoid)
+import Data.Monoid.Null (MonoidNull, PositiveMonoid)
+import Data.Semigroup.Cancellative (LeftCancellative, LeftReductive, RightCancellative, RightReductive)
+import Data.Semigroup.Factorial (Factorial, StableFactorial)
 import Data.Word (Word8)
 import GHC.Exts (IsList (Item, fromList, fromListN, toList))
 import Numeric (showHex)
@@ -124,7 +130,31 @@ newtype AsciiText = AsciiText ByteString
       -- | @since 1.0.0
       Monoid,
       -- | @since 1.0.0
-      Show
+      Show,
+      -- | @since 1.1.1
+      Factorial,
+      -- | @since 1.1.1
+      FactorialMonoid,
+      -- | @since 1.1.1
+      LeftCancellative,
+      -- | @since 1.1.1
+      LeftGCDMonoid,
+      -- | @since 1.1.1
+      LeftReductive,
+      -- | @since 1.1.1
+      MonoidNull,
+      -- | @since 1.1.1
+      OverlappingGCDMonoid,
+      -- | @since 1.1.1
+      PositiveMonoid,
+      -- | @since 1.1.1
+      RightCancellative,
+      -- | @since 1.1.1
+      RightGCDMonoid,
+      -- | @since 1.1.1
+      RightReductive,
+      -- | @since 1.1.1
+      StableFactorial
     )
     via ByteString
 

--- a/src/Text/Ascii/Unsafe.hs
+++ b/src/Text/Ascii/Unsafe.hs
@@ -111,29 +111,29 @@ newtype Unsafe (a :: Type) = Unsafe {safe :: a}
       TraversableStream,
       -- | @since 1.0.1
       Show,
-      -- | @since 1.1.1
+      -- | @since 1.2
       Factorial,
-      -- | @since 1.1.1
+      -- | @since 1.2
       FactorialMonoid,
-      -- | @since 1.1.1
+      -- | @since 1.2
       LeftCancellative,
-      -- | @since 1.1.1
+      -- | @since 1.2
       LeftGCDMonoid,
-      -- | @since 1.1.1
+      -- | @since 1.2
       LeftReductive,
-      -- | @since 1.1.1
+      -- | @since 1.2
       MonoidNull,
-      -- | @since 1.1.1
+      -- | @since 1.2
       OverlappingGCDMonoid,
-      -- | @since 1.1.1
+      -- | @since 1.2
       PositiveMonoid,
-      -- | @since 1.1.1
+      -- | @since 1.2
       RightCancellative,
-      -- | @since 1.1.1
+      -- | @since 1.2
       RightGCDMonoid,
-      -- | @since 1.1.1
+      -- | @since 1.2
       RightReductive,
-      -- | @since 1.1.1
+      -- | @since 1.2
       StableFactorial
     )
     via a

--- a/src/Text/Ascii/Unsafe.hs
+++ b/src/Text/Ascii/Unsafe.hs
@@ -47,6 +47,12 @@ import Data.CaseInsensitive (FoldCase)
 import Data.Coerce (coerce)
 import Data.Hashable (Hashable)
 import Data.Kind (Type)
+import Data.Monoid.Factorial (FactorialMonoid)
+import Data.Monoid.GCD (LeftGCDMonoid, RightGCDMonoid)
+import Data.Monoid.Monus (OverlappingGCDMonoid)
+import Data.Monoid.Null (MonoidNull, PositiveMonoid)
+import Data.Semigroup.Cancellative (LeftCancellative, LeftReductive, RightCancellative, RightReductive)
+import Data.Semigroup.Factorial (Factorial, StableFactorial)
 import Data.Word (Word8)
 import GHC.Exts (IsList)
 import GHC.Read (expectP, lexP, parens, readPrec)
@@ -104,7 +110,31 @@ newtype Unsafe (a :: Type) = Unsafe {safe :: a}
       -- | @since 1.0.1
       TraversableStream,
       -- | @since 1.0.1
-      Show
+      Show,
+      -- | @since 1.1.1
+      Factorial,
+      -- | @since 1.1.1
+      FactorialMonoid,
+      -- | @since 1.1.1
+      LeftCancellative,
+      -- | @since 1.1.1
+      LeftGCDMonoid,
+      -- | @since 1.1.1
+      LeftReductive,
+      -- | @since 1.1.1
+      MonoidNull,
+      -- | @since 1.1.1
+      OverlappingGCDMonoid,
+      -- | @since 1.1.1
+      PositiveMonoid,
+      -- | @since 1.1.1
+      RightCancellative,
+      -- | @since 1.1.1
+      RightGCDMonoid,
+      -- | @since 1.1.1
+      RightReductive,
+      -- | @since 1.1.1
+      StableFactorial
     )
     via a
   deriving stock

--- a/text-ascii.cabal
+++ b/text-ascii.cabal
@@ -35,6 +35,7 @@ library
     , deepseq           ^>=1.4.0.0
     , hashable          ^>=1.3.0.0
     , megaparsec        ^>=9.0.1
+    , monoid-subclasses >=1.0      && <1.2
     , optics-core       ^>=0.4
     , optics-extra      ^>=0.4
     , template-haskell  >=2.16.0.0 && <3.0.0.0


### PR DESCRIPTION
It turns out to be trivial. I took the liberty of adding `@since 1.1.1` comments, because I assume that would be the next release version.
